### PR TITLE
Http factory

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,9 @@
     "clean": "rm -rf dist",
     "lint": "tsc -b && eslint .",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
@@ -26,7 +28,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "@tanstack/react-query": "^5.90.10",
     "antd": "^5.29.1",
-    "axios": "^1.13.2",
+    "axios": "^1.15.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.526.0",
@@ -35,6 +37,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.66.1",
     "react-router": "^7.9.6",
+    "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.17",
@@ -58,6 +61,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.47.0",
-    "vite": "^7.2.2"
+    "vite": "^7.2.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/apps/web/src/services/api/account.ts
+++ b/apps/web/src/services/api/account.ts
@@ -1,6 +1,6 @@
 import type { IUpdatePasswordDto, IUpdateUserDto } from "../dtos/user";
 import type { IUser, IUserPermission } from "../types/user";
-import http from "./http";
+import http from "./new-http";
 
 /**
  * 获取当前用户信息

--- a/apps/web/src/services/api/auth.ts
+++ b/apps/web/src/services/api/auth.ts
@@ -1,6 +1,6 @@
 import type { ILoginDto, ILoginResponse, ISignUpDto } from "../dtos/auth";
 import type { IUser } from "../types/user";
-import http from "./http";
+import http from "./new-http";
 
 export const SignUp = async (data: ISignUpDto) => {
   const res = await http.post<IUser>("/auth/signup", data);

--- a/apps/web/src/services/api/cat.ts
+++ b/apps/web/src/services/api/cat.ts
@@ -1,6 +1,6 @@
 import type { ICreateCatDto, IUpdateCatOwnerDto } from "../dtos/cat";
 import type { ICat } from "../types/cat";
-import http from "./http";
+import http from "./new-http";
 
 export const GetCats = async () => {
   const res = await http.get<ICat[]>("/cats");

--- a/apps/web/src/services/api/group.ts
+++ b/apps/web/src/services/api/group.ts
@@ -6,7 +6,7 @@ import type {
   IUpdateGroupMemberDto,
 } from "../dtos/group";
 import type { IGroup } from "../types/group";
-import http from "./http";
+import http from "./new-http";
 
 export const CreateGroup = async (data: ICreateGroupDto) => {
   const res = await http.post<IGroup>("/groups", data);

--- a/apps/web/src/services/api/http-factory/README.md
+++ b/apps/web/src/services/api/http-factory/README.md
@@ -1,0 +1,136 @@
+# `http-factory`
+
+`createHttpClient` 是一个基于 `axios` 的 HTTP 客户端工厂函数，用来创建“带统一鉴权、自动刷新 access token 和错误归一化”的请求实例。
+
+## 实现了什么
+
+- 创建一个业务侧可直接使用的 `AxiosInstance`
+- 在请求阶段按需自动注入 `accessToken`
+- 遇到 `401` 或业务侧指定场景时自动尝试刷新 access token
+- 刷新请求由业务侧在 `refreshAccessToken` 中自行发起
+- 通过 `TokenRefreshManager` 合并并发刷新，避免同一时刻重复刷新
+- 成功时返回原始 `AxiosResponse`
+- 支持自定义业务成功判定、业务错误映射、刷新失败判定
+- 刷新失败或重试失败后统一执行 `onAuthFailure`
+- 大多数 axios 错误会统一归一化为带有 `status`、`data`、`response` 的 `Error`
+
+## 目录说明
+
+- `http-client.ts`
+  - 工厂函数 `createHttpClient`
+- `types.ts`
+  - 配置类型、请求选项
+- `token-refresh-manager.ts`
+  - 并发刷新控制
+- `http-demo.ts`
+  - `browserTokenStore`、示例实例、示例调用
+- `index.ts`
+  - 对外导出入口
+
+## 基本用法
+
+```ts
+import { createHttpClient } from "@/services/api/http-factory";
+
+const http = createHttpClient({
+  axiosConfig: {
+    baseURL: "/api",
+    timeout: 15 * 1000,
+  },
+  getAccessToken: () => localStorage.getItem("access_token"),
+  refreshAccessToken: async () => {
+    const refreshToken = localStorage.getItem("refresh_token");
+
+    if (!refreshToken) {
+      throw new Error("refreshToken 不存在");
+    }
+
+    const response = await axios.post("/auth/refresh", { refreshToken });
+
+    const data = response.data as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+
+    if (!data.accessToken) {
+      throw new Error("refresh 响应缺少 accessToken");
+    }
+
+    localStorage.setItem("access_token", data.accessToken);
+
+    if (data.refreshToken !== undefined) {
+      localStorage.setItem("refresh_token", data.refreshToken);
+    }
+
+    return data.accessToken;
+  },
+  onAuthFailure: async () => {
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("refresh_token");
+  },
+});
+
+const profile = await http.get("/account/profile");
+const profileData = profile.data;
+```
+
+## 请求约定
+
+这个工厂不再暴露额外的请求级开关：
+
+- 会自动注入 `accessToken`（内部刷新请求除外）
+- 配置了刷新能力时，遇到 `401` 或指定业务场景会自动尝试刷新
+- 未配置刷新能力时，`401` 会直接触发 `onAuthFailure`
+- `_retry` 仅作为内部状态使用，不对业务侧开放
+
+如果某类请求不希望带鉴权、不希望走自动刷新，建议直接使用独立的 `axios` 实例。
+
+## 默认流程
+
+1. 创建 `instance`
+2. 给 `instance` 挂请求拦截器
+3. 请求时读取 `accessToken`，并按配置注入请求头
+4. 响应时优先处理：
+   - 业务 token 失效判断
+   - 业务成功判断
+   - 成功时返回原始 `AxiosResponse`
+5. 若需要刷新 access token：
+   - 先判断是否启用了刷新能力
+   - 进入并发刷新保护
+   - 调用业务侧 `refreshAccessToken`
+   - 重放原请求
+6. 若刷新失败：
+   - 执行 `onAuthFailure`
+   - 抛出归一化后的错误
+
+## 适用场景
+
+适合这类前端项目：
+
+- 需要统一接入 JWT / access token
+- 有 refresh token 续期逻辑
+- 希望把 token 存储完全交给业务侧处理
+- 希望把请求层错误对象统一成一套结构
+- 希望保留 axios 原生 `AxiosResponse` 返回语义
+
+## 测试覆盖
+
+### createHttpClient
+
+1. 会透传 axiosConfig 给 axios.create
+2. 并发 401 请求只刷新一次，并在重试时使用新 token
+3. 显式传入的鉴权 header 不会被 token 注入覆盖
+4. refresh 失败时只触发 onAuthFailure
+5. 业务响应命中 accessToken 失效 code 时会刷新并重试
+6. refresh 返回空字符串 refreshToken 时会交给使用者自行处理
+7. 未启用刷新时，401 会触发 onAuthFailure 且不会读取 refreshToken
+8. 非 401 的 axios 错误会被归一化为 HttpError
+9. 重试后的请求再次返回 401 时会停止重试并退出登录
+
+### createHttpClient edge cases
+
+1. 自定义 unauthorizedStatusCode 命中时会刷新并重试
+2. 业务响应要求刷新但未启用刷新时会原样返回响应
+3. 并发 401 请求在 refresh 返回 500 时只触发一次 onAuthFailure
+4. refresh 错误命中 authFailureCodes 时会视为登录过期
+5. refresh 抛出非 Error 异常时会归一化为未知错误

--- a/apps/web/src/services/api/http-factory/__tests__/http-client.edge-cases.test.ts
+++ b/apps/web/src/services/api/http-factory/__tests__/http-client.edge-cases.test.ts
@@ -269,8 +269,9 @@ describe("createHttpClient edge cases", () => {
   it("refresh 进行中时新来的 401 请求会复用同一次 refresh", async () => {
     const tokenStore = createTokenStore("old-access", "old-refresh");
     const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
-    let releaseRefresh: ((value: void | PromiseLike<void>) => void) | null =
-      null;
+    let releaseRefresh: (value?: void | PromiseLike<void>) => void = () => {
+      throw new Error("refresh resolver not initialized");
+    };
 
     const refreshStarted = new Promise<void>((resolve) => {
       releaseRefresh = resolve;
@@ -367,9 +368,7 @@ describe("createHttpClient edge cases", () => {
     const firstRequest = http.get("/profile");
     await waitRefreshStarted;
     const secondRequest = http.get("/me");
-    if (releaseRefresh) {
-      releaseRefresh();
-    }
+    releaseRefresh();
 
     const [first, second] = await Promise.all([firstRequest, secondRequest]);
 

--- a/apps/web/src/services/api/http-factory/__tests__/http-client.edge-cases.test.ts
+++ b/apps/web/src/services/api/http-factory/__tests__/http-client.edge-cases.test.ts
@@ -1,0 +1,468 @@
+import { describe, expect, it, vi } from "vitest";
+import "./test-utils/mock-axios";
+
+import { createHttpClient } from "../";
+import {
+  createRefreshAccessToken,
+  createTokenStore,
+  queueAxiosError,
+  queueCustomHandler,
+  queueMatchedHandler,
+  queueResponse,
+} from "./test-utils/mock-axios";
+
+describe("createHttpClient edge cases", () => {
+  it("命中 skipRefreshUrls 时，401 不会触发 refresh", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {});
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+      skipRefreshUrls: ["/auth/login"],
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+
+    await expect(
+      http.post("/auth/login", { account: "u", password: "p" }),
+    ).rejects.toMatchObject({
+      name: "HttpError",
+      message: "Request failed",
+      status: 401,
+    });
+
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(tokenStore.getRefreshToken).not.toHaveBeenCalled();
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("命中 skipRefreshUrls 时，业务响应触发刷新也不会执行 refresh", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken,
+      skipRefreshUrls: ["/auth/login"],
+      shouldRefreshByResponseData: (response) => {
+        const data = response.data as { code?: number };
+        return data.code === 40101;
+      },
+    });
+
+    queueResponse({
+      status: 200,
+      data: { code: 40101, message: "token expired" },
+    });
+
+    const response = await http.post("/auth/login", {
+      account: "u",
+      password: "p",
+    });
+
+    expect(response.data).toEqual({ code: 40101, message: "token expired" });
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    expect(tokenStore.getRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("自定义 unauthorizedStatusCode 命中时会刷新并重试", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      unauthorizedStatusCode: 498,
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 498, data: { message: "token expired" } });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+      },
+    });
+
+    let retriedAuthorization = "";
+
+    queueCustomHandler(async (config) => {
+      retriedAuthorization = config.headers?.Authorization;
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    const response = await http.get("/profile");
+
+    expect(response.data).toEqual({ ok: true });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).toHaveBeenCalledWith("new-access");
+    expect(retriedAuthorization).toBe("Bearer new-access");
+  });
+
+  it("业务响应要求刷新但未启用刷新时会直接返回原响应", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {});
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      shouldRefreshByResponseData: () => true,
+    });
+
+    queueResponse({
+      status: 200,
+      data: { code: 40101, message: "token expired" },
+    });
+
+    const response = await http.get("/profile");
+
+    expect(response.data).toEqual({ code: 40101, message: "token expired" });
+    expect(onAuthFailure).not.toHaveBeenCalled();
+  });
+
+  it("refresh 成功响应缺少 accessToken 时会触发鉴权失败且不重试原请求", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {});
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueResponse({
+      status: 200,
+      data: {
+        refreshToken: "new-refresh",
+      },
+    });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      message: "missing accessToken",
+    });
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.getRefreshToken).toHaveBeenCalledTimes(1);
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).not.toHaveBeenCalled();
+    expect(tokenStore.setRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("并发 401 请求在 refresh 返回 500 时只触发一次 onAuthFailure", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {
+      tokenStore.clearAuth();
+    });
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueAxiosError({
+      message: "refresh server error",
+      status: 500,
+      data: { code: 50001, message: "server error" },
+    });
+
+    const results = await Promise.allSettled([
+      http.get("/profile"),
+      http.get("/me"),
+    ]);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        status: "rejected",
+        reason: expect.objectContaining({
+          name: "HttpError",
+          message: "refresh server error",
+          status: 500,
+        }),
+      }),
+      expect.objectContaining({
+        status: "rejected",
+        reason: expect.objectContaining({
+          name: "HttpError",
+          message: "refresh server error",
+          status: 500,
+        }),
+      }),
+    ]);
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.getRefreshToken).toHaveBeenCalledTimes(1);
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    expect(tokenStore.clearAuth).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("重试后的业务响应再次命中刷新条件时会停止重试并退出登录", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {});
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+      shouldRefreshByResponseData: (response) => {
+        const data = response.data as { code?: number };
+        return data.code === 40101;
+      },
+    });
+
+    queueResponse({
+      status: 200,
+      data: { code: 40101, message: "token expired" },
+    });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+      },
+    });
+    queueResponse({
+      status: 200,
+      data: { code: 40101, message: "still expired" },
+    });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "登录已失效，请重新登录",
+    });
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setRefreshToken).toHaveBeenCalledWith("new-refresh");
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh 进行中时新来的 401 请求会复用同一次 refresh", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+    let releaseRefresh: ((value: void | PromiseLike<void>) => void) | null =
+      null;
+
+    const refreshStarted = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+
+    let notifyRefreshStarted: (() => void) | null = null;
+
+    const waitRefreshStarted = new Promise<void>((resolve) => {
+      notifyRefreshStarted = resolve;
+    });
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken,
+    });
+
+    queueMatchedHandler(
+      (config) => config.url === "/profile" && !config._retry,
+      async (config) => {
+        const error = new Error("unauthorized") as Error & {
+          config: any;
+          isAxiosError: boolean;
+          response?: { status?: number; data?: unknown; config: any };
+        };
+
+        error.config = config;
+        error.isAxiosError = true;
+        error.response = {
+          status: 401,
+          data: { message: "unauthorized" },
+          config,
+        };
+
+        throw error;
+      },
+    );
+    queueMatchedHandler(
+      (config) => config.url === "/me" && !config._retry,
+      async (config) => {
+        const error = new Error("unauthorized") as Error & {
+          config: any;
+          isAxiosError: boolean;
+          response?: { status?: number; data?: unknown; config: any };
+        };
+
+        error.config = config;
+        error.isAxiosError = true;
+        error.response = {
+          status: 401,
+          data: { message: "unauthorized" },
+          config,
+        };
+
+        throw error;
+      },
+    );
+    queueMatchedHandler(
+      (config) => config.url === "/auth/refresh",
+      async (config) => {
+        notifyRefreshStarted?.();
+        await refreshStarted;
+
+        return {
+          status: 200,
+          data: {
+            accessToken: "new-access",
+            refreshToken: "new-refresh",
+          },
+          config,
+        };
+      },
+    );
+
+    const retriedAuthorizations: string[] = [];
+
+    queueMatchedHandler(
+      (config) => config.url === "/profile" && config._retry,
+      async (config) => {
+        retriedAuthorizations.push(config.headers?.Authorization);
+        return { status: 200, data: { ok: "first" }, config };
+      },
+    );
+    queueMatchedHandler(
+      (config) => config.url === "/me" && config._retry,
+      async (config) => {
+        retriedAuthorizations.push(config.headers?.Authorization);
+        return { status: 200, data: { ok: "second" }, config };
+      },
+    );
+
+    const firstRequest = http.get("/profile");
+    await waitRefreshStarted;
+    const secondRequest = http.get("/me");
+    if (releaseRefresh) {
+      releaseRefresh();
+    }
+
+    const [first, second] = await Promise.all([firstRequest, secondRequest]);
+
+    expect(first.data).toEqual({ ok: "first" });
+    expect(second.data).toEqual({ ok: "second" });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.getRefreshToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setRefreshToken).toHaveBeenCalledWith("new-refresh");
+    expect(retriedAuthorizations).toEqual([
+      "Bearer new-access",
+      "Bearer new-access",
+    ]);
+  });
+
+  it("refresh 错误命中 authFailureCodes 时会视为登录过期", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {});
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      authFailureCodes: [1001002],
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken: createRefreshAccessToken(tokenStore),
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueAxiosError({
+      message: "refresh forbidden",
+      status: 403,
+      data: { code: 1001002, message: "refresh expired" },
+    });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "refreshToken 已失效，登录过期",
+    });
+
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh 抛出非 Error 异常时会归一化为未知错误", async () => {
+    const onAuthFailure = vi.fn(async () => {});
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: async () => "old-access",
+      onAuthFailure,
+      refreshAccessToken: async () => {
+        throw { reason: "boom" };
+      },
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      message: "未知错误",
+    });
+
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("onAuthFailure 抛错时会透出回调错误而不是原始鉴权错误", async () => {
+    const onAuthFailure = vi.fn(async () => {
+      throw new Error("cleanup failed");
+    });
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: async () => "old-access",
+      onAuthFailure,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      message: "cleanup failed",
+    });
+
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    expect(onAuthFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "HttpError",
+        message: "Request failed",
+        status: 401,
+      }),
+    );
+  });
+});

--- a/apps/web/src/services/api/http-factory/__tests__/http-client.test.ts
+++ b/apps/web/src/services/api/http-factory/__tests__/http-client.test.ts
@@ -1,0 +1,330 @@
+import "./test-utils/mock-axios";
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+
+import { createHttpClient } from "../";
+import {
+  createRefreshAccessToken,
+  createTokenStore,
+  queueAxiosError,
+  queueCustomHandler,
+  queueResponse,
+} from "./test-utils/mock-axios";
+
+describe("createHttpClient", () => {
+  it("会透传 axiosConfig 给 axios.create", () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+
+    createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+        timeout: 20 * 1000,
+        withCredentials: true,
+        headers: {
+          "X-App": "web",
+        },
+      },
+      getAccessToken: tokenStore.getAccessToken,
+    });
+
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: "/api",
+      timeout: 20 * 1000,
+      withCredentials: true,
+      headers: {
+        "X-App": "web",
+      },
+    });
+  });
+
+  it("并发 401 请求只刷新一次，并在重试时使用新 token", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+      },
+    });
+
+    const retriedAuthHeaders: string[] = [];
+
+    queueCustomHandler(async (config) => {
+      retriedAuthHeaders.push(config.headers?.Authorization);
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    queueCustomHandler(async (config) => {
+      retriedAuthHeaders.push(config.headers?.Authorization);
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    const [first, second] = await Promise.all([
+      http.get("/profile"),
+      http.get("/me"),
+    ]);
+
+    expect(first.data).toEqual({ ok: true });
+    expect(second.data).toEqual({ ok: true });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.getRefreshToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setRefreshToken).toHaveBeenCalledWith("new-refresh");
+    expect(retriedAuthHeaders).toEqual([
+      "Bearer new-access",
+      "Bearer new-access",
+    ]);
+  });
+
+  it("显式传入的鉴权 header 不会被 token 注入覆盖", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken: createRefreshAccessToken(tokenStore),
+    });
+
+    let receivedAuthorization = "";
+
+    queueCustomHandler(async (config) => {
+      receivedAuthorization = config.headers?.Authorization;
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    await http.get("/profile", {
+      headers: {
+        Authorization: "Bearer explicit-token",
+      },
+    });
+
+    expect(receivedAuthorization).toBe("Bearer explicit-token");
+    expect(tokenStore.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("getAccessToken 为空时不会注入鉴权 header", async () => {
+    const getAccessToken = vi.fn(async () => "");
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken,
+    });
+
+    let receivedAuthorization: unknown;
+
+    queueCustomHandler(async (config) => {
+      receivedAuthorization = config.headers?.Authorization;
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    const response = await http.get("/profile");
+
+    expect(response.data).toEqual({ ok: true });
+    expect(getAccessToken).toHaveBeenCalledTimes(1);
+    expect(receivedAuthorization).toBeUndefined();
+  });
+
+  it("refresh 失败时会触发一次 onAuthFailure 并返回登录过期错误", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const onAuthFailure = vi.fn(async () => {
+      tokenStore.clearAuth();
+    });
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueAxiosError({ status: 401, data: { message: "refresh expired" } });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "refreshToken 已失效，登录过期",
+    });
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.clearAuth).toHaveBeenCalledTimes(1);
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("业务响应命中 accessToken 失效 code 时会刷新并重试", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken: createRefreshAccessToken(tokenStore),
+      shouldRefreshByResponseData: (response) => {
+        const data = response.data as { code?: number };
+        return data.code === 40101;
+      },
+    });
+
+    queueResponse({
+      status: 200,
+      data: { code: 40101, message: "token expired" },
+    });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+      },
+    });
+
+    let retriedAuthorization = "";
+
+    queueCustomHandler(async (config) => {
+      retriedAuthorization = config.headers?.Authorization;
+      return { status: 200, data: { ok: true }, config };
+    });
+
+    const response = await http.get("/profile");
+
+    expect(response.data).toEqual({ ok: true });
+    expect(tokenStore.setAccessToken).toHaveBeenCalledTimes(1);
+    expect(retriedAuthorization).toBe("Bearer new-access");
+  });
+
+  it("refresh 返回空字符串 refreshToken 时会交给使用者自行处理", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+        refreshToken: "",
+      },
+    });
+    queueResponse({
+      status: 200,
+      data: { ok: true },
+    });
+
+    const response = await http.get("/profile");
+
+    expect(response.data).toEqual({ ok: true });
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(tokenStore.setAccessToken).toHaveBeenCalledWith("new-access");
+    expect(tokenStore.setRefreshToken).toHaveBeenCalledWith("");
+  });
+
+  it("未启用刷新时，401 会触发 onAuthFailure 且不会读取 refreshToken", async () => {
+    const onAuthFailure = vi.fn(async () => {});
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "Request failed",
+      status: 401,
+    });
+
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+    expect(tokenStore.getRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it("非 401 的 axios 错误会被归一化为 HttpError", async () => {
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      refreshAccessToken: createRefreshAccessToken(tokenStore),
+    });
+
+    queueAxiosError({
+      message: "Request failed",
+      status: 500,
+      data: { code: 50001, message: "server error" },
+    });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "Request failed",
+      status: 500,
+      data: { code: 50001, message: "server error" },
+    });
+
+    expect(tokenStore.clearAuth).not.toHaveBeenCalled();
+    expect(tokenStore.setAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("重试后的请求再次返回 401 时会停止重试并退出登录", async () => {
+    const onAuthFailure = vi.fn(async () => {});
+    const tokenStore = createTokenStore("old-access", "old-refresh");
+    const refreshAccessToken = vi.fn(createRefreshAccessToken(tokenStore));
+
+    const http = createHttpClient({
+      axiosConfig: {
+        baseURL: "/api",
+      },
+      getAccessToken: tokenStore.getAccessToken,
+      onAuthFailure,
+      refreshAccessToken,
+    });
+
+    queueAxiosError({ status: 401, data: { message: "unauthorized" } });
+    queueResponse({
+      status: 200,
+      data: {
+        accessToken: "new-access",
+      },
+    });
+    queueAxiosError({ status: 401, data: { message: "still unauthorized" } });
+
+    await expect(http.get("/profile")).rejects.toMatchObject({
+      name: "HttpError",
+      message: "登录已失效，请重新登录",
+    });
+
+    expect(refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(onAuthFailure).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/services/api/http-factory/__tests__/test-utils/mock-axios.ts
+++ b/apps/web/src/services/api/http-factory/__tests__/test-utils/mock-axios.ts
@@ -1,0 +1,265 @@
+import axios from "axios";
+import { afterEach, vi } from "vitest";
+
+type MockHandler = (config: any) => Promise<any>;
+
+type MatchedMockHandler = {
+  handler: MockHandler;
+  matcher: (config: any) => boolean;
+};
+
+const mockHandlers: MockHandler[] = [];
+const matchedMockHandlers: MatchedMockHandler[] = [];
+
+vi.mock("axios", async () => {
+  const actual = await vi.importActual<typeof import("axios")>("axios");
+
+  class MockAxiosInstance {
+    public interceptors = {
+      request: {
+        handlers: [] as Array<{
+          fulfilled?: (value: any) => any;
+          rejected?: (error: unknown) => unknown;
+        }>,
+        use: (
+          fulfilled?: (value: any) => any,
+          rejected?: (error: unknown) => unknown,
+        ) => {
+          this.interceptors.request.handlers.push({ fulfilled, rejected });
+          return this.interceptors.request.handlers.length - 1;
+        },
+      },
+      response: {
+        handlers: [] as Array<{
+          fulfilled?: (value: any) => any;
+          rejected?: (error: unknown) => unknown;
+        }>,
+        use: (
+          fulfilled?: (value: any) => any,
+          rejected?: (error: unknown) => unknown,
+        ) => {
+          this.interceptors.response.handlers.push({ fulfilled, rejected });
+          return this.interceptors.response.handlers.length - 1;
+        },
+      },
+    };
+
+    async request(config: any) {
+      let nextConfig = config;
+
+      for (const handler of this.interceptors.request.handlers) {
+        if (handler.fulfilled) {
+          nextConfig = await handler.fulfilled(nextConfig);
+        }
+      }
+
+      const matchedHandlerIndex = matchedMockHandlers.findIndex(({ matcher }) => {
+        return matcher(nextConfig);
+      });
+
+      const handler =
+        matchedHandlerIndex >= 0
+          ? matchedMockHandlers.splice(matchedHandlerIndex, 1)[0]?.handler
+          : mockHandlers.shift();
+
+      if (!handler) {
+        throw new Error(
+          `No mock handler for ${nextConfig.method || "get"} ${nextConfig.url}`,
+        );
+      }
+
+      try {
+        let response = await handler(nextConfig);
+
+        if (!response.config) {
+          response = { ...response, config: nextConfig };
+        }
+
+        for (const responseHandler of this.interceptors.response.handlers) {
+          if (responseHandler.fulfilled) {
+            response = await responseHandler.fulfilled(response);
+          }
+        }
+
+        return response;
+      } catch (error) {
+        let nextError = error;
+
+        if (
+          nextError &&
+          typeof nextError === "object" &&
+          !("config" in nextError)
+        ) {
+          if (nextError instanceof Error) {
+            Object.assign(nextError, { config: nextConfig });
+          } else {
+            nextError = { ...nextError, config: nextConfig };
+          }
+        }
+
+        for (const responseHandler of this.interceptors.response.handlers) {
+          if (!responseHandler.rejected) continue;
+
+          try {
+            return await responseHandler.rejected(nextError);
+          } catch (handledError) {
+            nextError = handledError;
+          }
+        }
+
+        throw nextError;
+      }
+    }
+
+    get(url: string, config?: any) {
+      return this.request({ ...config, method: "get", url });
+    }
+
+    post(url: string, data?: any, config?: any) {
+      return this.request({ ...config, data, method: "post", url });
+    }
+  }
+
+  return {
+    ...actual,
+    post: vi.fn((url: string, data?: any, config?: any) => {
+      const instance = new MockAxiosInstance();
+      return instance.post(url, data, config);
+    }),
+    default: {
+      ...actual.default,
+      create: vi.fn(() => new MockAxiosInstance()),
+      post: vi.fn((url: string, data?: any, config?: any) => {
+        const instance = new MockAxiosInstance();
+        return instance.post(url, data, config);
+      }),
+      isAxiosError: actual.default.isAxiosError,
+    },
+    create: vi.fn(() => new MockAxiosInstance()),
+    isAxiosError: actual.isAxiosError,
+  };
+});
+
+export const queueResponse = (response: {
+  status: number;
+  data: unknown;
+  config?: any;
+}) => {
+  mockHandlers.push(async (config) => ({
+    ...response,
+    config: response.config ?? config,
+  }));
+};
+
+export const queueCustomHandler = (handler: MockHandler) => {
+  mockHandlers.push(handler);
+};
+
+export const queueMatchedHandler = (
+  matcher: (config: any) => boolean,
+  handler: MockHandler,
+) => {
+  matchedMockHandlers.push({ matcher, handler });
+};
+
+export const queueAxiosError = ({
+  message = "Request failed",
+  status,
+  data,
+}: {
+  message?: string;
+  status?: number;
+  data?: unknown;
+}) => {
+  mockHandlers.push(async (config) => {
+    const error = new Error(message) as Error & {
+      config: any;
+      isAxiosError: boolean;
+      response?: { status?: number; data?: unknown; config: any };
+    };
+
+    error.config = config;
+    error.isAxiosError = true;
+    error.response = {
+      status,
+      data,
+      config,
+    };
+
+    throw error;
+  });
+};
+
+export const createTokenStore = (
+  initialAccessToken: string,
+  initialRefreshToken: string,
+) => {
+  let accessToken = initialAccessToken;
+  let refreshToken = initialRefreshToken;
+  let staleAccessTokenReadCount = 0;
+
+  return {
+    getAccessToken: vi.fn(async () => {
+      if (staleAccessTokenReadCount > 0) {
+        staleAccessTokenReadCount -= 1;
+        return initialAccessToken;
+      }
+
+      return accessToken;
+    }),
+    getRefreshToken: vi.fn(async () => refreshToken),
+    setAccessToken: vi.fn((nextAccessToken: string) => {
+      accessToken = nextAccessToken;
+      staleAccessTokenReadCount = 1;
+    }),
+    setRefreshToken: vi.fn((nextRefreshToken: string) => {
+      refreshToken = nextRefreshToken;
+    }),
+    clearAuth: vi.fn(() => {
+      accessToken = "";
+      refreshToken = "";
+    }),
+  };
+};
+
+export const createRefreshAccessToken = (
+  tokenStore: ReturnType<typeof createTokenStore>,
+) => {
+  return async () => {
+    const refreshToken = await tokenStore.getRefreshToken();
+
+    if (!refreshToken) {
+      throw new Error("missing refreshToken");
+    }
+
+    const response = await axios.post("/auth/refresh", { refreshToken });
+    const data = response.data as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+
+    if (!data.accessToken) {
+      throw new Error("missing accessToken");
+    }
+
+    tokenStore.setAccessToken(data.accessToken);
+
+    if (data.refreshToken !== undefined) {
+      tokenStore.setRefreshToken(data.refreshToken);
+    }
+
+    return data.accessToken;
+  };
+};
+
+export const wait = (ms: number) => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+afterEach(() => {
+  mockHandlers.length = 0;
+  matchedMockHandlers.length = 0;
+  vi.clearAllMocks();
+});

--- a/apps/web/src/services/api/http-factory/http-demo.ts
+++ b/apps/web/src/services/api/http-factory/http-demo.ts
@@ -78,19 +78,27 @@ export const http = createHttpClient({
     const data = response.data as {
       accessToken?: string;
       refreshToken?: string;
+      expiresAt?: string;
     };
 
     if (!data.accessToken) {
       throw new Error("refresh 响应缺少 accessToken");
     }
 
-    browserTokenStore.setAccessToken(data.accessToken);
+    const expiresAt = data.expiresAt
+      ? new Date(data.expiresAt)
+      : new Date(Date.now() + 15 * 60_000);
+
+    browserTokenStore.setAccessToken(data.accessToken, expiresAt);
 
     if (data.refreshToken !== undefined) {
       browserTokenStore.setRefreshToken(data.refreshToken);
     }
 
-    return data.accessToken;
+    return {
+      token: data.accessToken,
+      expiresAt,
+    };
   },
   shouldRefreshByResponseData: (response) => {
     const data = response.data as { code?: number };

--- a/apps/web/src/services/api/http-factory/http-demo.ts
+++ b/apps/web/src/services/api/http-factory/http-demo.ts
@@ -1,0 +1,107 @@
+/**
+ * 示例文件：展示如何使用 createHttpClient 创建带 token 刷新的 HTTP 实例。
+ * 实际项目中请根据需求调整配置，或创建独立的 client 文件。
+ */
+import axios from "axios";
+import { createHttpClient } from "./";
+
+const ACCESS_TOKEN_STORAGE_KEY = "APP_ACCESS_TOKEN";
+const REFRESH_TOKEN_STORAGE_KEY = "APP_REFRESH_TOKEN";
+
+export const browserTokenStore = {
+  getAccessToken(): string | null {
+    if (typeof window === "undefined") return null;
+    return window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+  },
+
+  getRefreshToken(): string | null {
+    if (typeof window === "undefined") return null;
+    return window.localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY);
+  },
+
+  setAccessToken(accessToken: string) {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  },
+
+  setRefreshToken(refreshToken: string) {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
+  },
+
+  clearAuth() {
+    if (typeof window === "undefined") return;
+    window.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+    window.localStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+  },
+};
+
+export const http = createHttpClient({
+  axiosConfig: {
+    baseURL: "/api",
+    timeout: 15 * 1000,
+  },
+  authFailureCodes: [40103, 1001002],
+  getAccessToken: () => browserTokenStore.getAccessToken(),
+  refreshAccessToken: async () => {
+    const refreshToken = browserTokenStore.getRefreshToken();
+
+    if (!refreshToken) {
+      throw new Error("refreshToken 不存在");
+    }
+
+    const response = await axios.post<unknown>("/auth/refresh", {
+      refreshToken,
+    });
+
+    const data = response.data as {
+      accessToken?: string;
+      refreshToken?: string;
+    };
+
+    if (!data.accessToken) {
+      throw new Error("refresh 响应缺少 accessToken");
+    }
+
+    browserTokenStore.setAccessToken(data.accessToken);
+
+    if (data.refreshToken !== undefined) {
+      browserTokenStore.setRefreshToken(data.refreshToken);
+    }
+
+    return data.accessToken;
+  },
+  shouldRefreshByResponseData: (response) => {
+    const data = response.data as { code?: number };
+    return data.code === 40101 || data.code === 1001001;
+  },
+  isRefreshFailure: (error) => {
+    if (!(error instanceof Error) || !("response" in error)) {
+      return false;
+    }
+
+    const response = error.response as
+      | { status?: number; data?: { code?: number } }
+      | undefined;
+
+    if (!response || (response.status && response.status >= 500)) {
+      return false;
+    }
+
+    return response.status === 401 || response.data?.code === 40103;
+  },
+  onAuthFailure: () => {
+    browserTokenStore.clearAuth();
+
+    if (typeof window === "undefined") return;
+
+    const loginPath = "/login";
+    if (window.location.pathname !== loginPath) {
+      window.location.href = loginPath;
+    }
+  },
+});
+
+export const getDemoProfile = async () => {
+  return http.get("/account/profile");
+};

--- a/apps/web/src/services/api/http-factory/http-demo.ts
+++ b/apps/web/src/services/api/http-factory/http-demo.ts
@@ -8,10 +8,25 @@ import { createHttpClient } from "./";
 const ACCESS_TOKEN_STORAGE_KEY = "APP_ACCESS_TOKEN";
 const REFRESH_TOKEN_STORAGE_KEY = "APP_REFRESH_TOKEN";
 
+const EXPIRES_AT_STORAGE_KEY = "APP_EXPIRES_AT";
+
 export const browserTokenStore = {
   getAccessToken(): string | null {
     if (typeof window === "undefined") return null;
     return window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+  },
+
+  getAccessTokenDetail() {
+    const token = browserTokenStore.getAccessToken();
+    if (!token) return null;
+
+    const expiresAtRaw = window.localStorage.getItem(EXPIRES_AT_STORAGE_KEY);
+    const expiresAt = expiresAtRaw ? new Date(expiresAtRaw) : null;
+
+    return {
+      token,
+      expiresAt: expiresAt ?? new Date(Date.now() + 15 * 60_000),
+    };
   },
 
   getRefreshToken(): string | null {
@@ -19,9 +34,13 @@ export const browserTokenStore = {
     return window.localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY);
   },
 
-  setAccessToken(accessToken: string) {
+  setAccessToken(accessToken: string, expiresAt?: Date) {
     if (typeof window === "undefined") return;
     window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+
+    if (expiresAt) {
+      window.localStorage.setItem(EXPIRES_AT_STORAGE_KEY, expiresAt.toISOString());
+    }
   },
 
   setRefreshToken(refreshToken: string) {
@@ -33,6 +52,7 @@ export const browserTokenStore = {
     if (typeof window === "undefined") return;
     window.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
     window.localStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY);
+    window.localStorage.removeItem(EXPIRES_AT_STORAGE_KEY);
   },
 };
 
@@ -42,7 +62,8 @@ export const http = createHttpClient({
     timeout: 15 * 1000,
   },
   authFailureCodes: [40103, 1001002],
-  getAccessToken: () => browserTokenStore.getAccessToken(),
+  // 返回 AccessTokenDetail 时，会在 token 即将过期前主动触发刷新
+  getAccessToken: () => browserTokenStore.getAccessTokenDetail(),
   refreshAccessToken: async () => {
     const refreshToken = browserTokenStore.getRefreshToken();
 

--- a/apps/web/src/services/api/http-factory/index.ts
+++ b/apps/web/src/services/api/http-factory/index.ts
@@ -111,11 +111,13 @@ const shouldSkipRefresh = (
   return skipRefreshUrls.some((url) => requestUrl.includes(url));
 };
 
-export const createHttpClient = (options: HttpClientOptions): AxiosInstance => {
+export const createHttpClient = <T extends AccessTokenResult = AccessTokenResult>(
+  options: HttpClientOptions<T>,
+): AxiosInstance => {
   const refreshManager = new TokenRefreshManager();
   const refreshEnabled = options.refreshAccessToken !== undefined;
 
-  const resolvedOptions: ResolvedHttpClientOptions = {
+  const resolvedOptions: ResolvedHttpClientOptions<T> = {
     authFailureCodes: [],
     accessTokenHeaderName: "Authorization",
     accessTokenPrefix: "Bearer",
@@ -166,7 +168,7 @@ export const createHttpClient = (options: HttpClientOptions): AxiosInstance => {
     await resolvedOptions.onAuthFailure(error);
   };
 
-  const refreshAccessToken = async (): Promise<string> => {
+  const refreshAccessToken = async (): Promise<AccessTokenResult> => {
     const requestRefreshAccessToken = resolvedOptions.refreshAccessToken;
 
     if (!refreshEnabled || !requestRefreshAccessToken) {
@@ -201,12 +203,13 @@ export const createHttpClient = (options: HttpClientOptions): AxiosInstance => {
     config._retry = true;
 
     try {
-      const newAccessToken = await refreshAccessToken();
+      const refreshResult = await refreshAccessToken();
+      const { token } = normalizeTokenResult(refreshResult);
 
       config.headers = config.headers ?? {};
       config.headers[resolvedOptions.accessTokenHeaderName] = formatAccessToken(
         resolvedOptions.accessTokenPrefix,
-        newAccessToken,
+        token,
       );
 
       return await instance.request(config);

--- a/apps/web/src/services/api/http-factory/index.ts
+++ b/apps/web/src/services/api/http-factory/index.ts
@@ -6,6 +6,7 @@ import type {
 import axios, { AxiosError } from "axios";
 import { TokenRefreshManager } from "./token-refresh-manager";
 import type {
+  AccessTokenResult,
   HttpClientOptions,
   RequestRetryState,
   ResolvedHttpClientOptions,
@@ -24,6 +25,8 @@ const HTTP_CLIENT_MESSAGES = {
   refreshTokenExpired: "refreshToken 已失效，登录过期",
   loginExpired: "登录已失效，请重新登录",
 };
+
+const DEFAULT_REFRESH_BUFFER_MS = 60_000;
 
 const createHttpClientError = <T = unknown>(
   message: string,
@@ -74,6 +77,25 @@ const overrideErrorMessage = <T>(error: T): T => {
 const formatAccessToken = (prefix: string, token: string) => {
   const normalizedPrefix = prefix.trim();
   return normalizedPrefix ? `${normalizedPrefix} ${token}` : token;
+};
+
+const normalizeTokenResult = (result: AccessTokenResult) => {
+  if (!result || typeof result === "string") {
+    return { token: result ?? "", expiresAt: null, refreshBufferMs: undefined };
+  }
+
+  return {
+    token: result.token,
+    expiresAt: new Date(result.expiresAt),
+    refreshBufferMs: result.refreshBufferMs,
+  };
+};
+
+const isTokenExpiringSoon = (
+  expiresAt: Date,
+  refreshBufferMs: number,
+): boolean => {
+  return Date.now() >= expiresAt.getTime() - refreshBufferMs;
 };
 
 const shouldSkipRefresh = (
@@ -202,13 +224,29 @@ export const createHttpClient = (options: HttpClientOptions): AxiosInstance => {
         return config;
       }
 
-      const accessToken = await resolvedOptions.getAccessToken();
-      if (!accessToken) return config;
+      const tokenResult = await resolvedOptions.getAccessToken();
+      const { token, expiresAt, refreshBufferMs } =
+        normalizeTokenResult(tokenResult);
+
+      if (!token) return config;
+
+      // 主动刷新：token 即将过期时异步触发刷新，不阻塞当前请求
+      if (
+        refreshEnabled &&
+        expiresAt &&
+        !shouldSkipRefresh(resolvedOptions.skipRefreshUrls, config)
+      ) {
+        const bufferMs = refreshBufferMs ?? DEFAULT_REFRESH_BUFFER_MS;
+
+        if (bufferMs > 0 && isTokenExpiringSoon(expiresAt, bufferMs)) {
+          refreshAccessToken().catch(() => {});
+        }
+      }
 
       config.headers = config.headers ?? {};
       config.headers[resolvedOptions.accessTokenHeaderName] = formatAccessToken(
         resolvedOptions.accessTokenPrefix,
-        accessToken,
+        token,
       );
 
       return config;

--- a/apps/web/src/services/api/http-factory/index.ts
+++ b/apps/web/src/services/api/http-factory/index.ts
@@ -262,14 +262,11 @@ export const createHttpClient = <T extends AccessTokenResult = AccessTokenResult
       const config = response.config as InternalAxiosRequestConfig &
         RequestRetryState;
 
-      if (resolvedOptions.shouldRefreshByResponseData(response)) {
-        if (
-          !refreshEnabled ||
-          shouldSkipRefresh(resolvedOptions.skipRefreshUrls, config)
-        ) {
-          return response;
-        }
-
+      if (
+        resolvedOptions.shouldRefreshByResponseData(response) &&
+        refreshEnabled &&
+        !shouldSkipRefresh(resolvedOptions.skipRefreshUrls, config)
+      ) {
         return retryAfterRefresh(config);
       }
 

--- a/apps/web/src/services/api/http-factory/index.ts
+++ b/apps/web/src/services/api/http-factory/index.ts
@@ -1,0 +1,276 @@
+import type {
+  AxiosInstance,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios";
+import axios, { AxiosError } from "axios";
+import { TokenRefreshManager } from "./token-refresh-manager";
+import type {
+  HttpClientOptions,
+  RequestRetryState,
+  ResolvedHttpClientOptions,
+} from "./types";
+
+type HttpClientError<T = unknown> = Error & {
+  status?: number;
+  data?: T;
+  response?: AxiosResponse<T>;
+};
+
+const HTTP_CLIENT_MESSAGES = {
+  requestFailed: "请求失败",
+  businessRequestFailed: "业务请求失败",
+  refreshDisabled: "未启用 refresh token 逻辑",
+  refreshTokenExpired: "refreshToken 已失效，登录过期",
+  loginExpired: "登录已失效，请重新登录",
+};
+
+const createHttpClientError = <T = unknown>(
+  message: string,
+  options?: {
+    status?: number;
+    data?: T;
+    response?: AxiosResponse<T>;
+  },
+): HttpClientError<T> => {
+  const error = new Error(message) as HttpClientError<T>;
+
+  error.name = "HttpError";
+  error.status = options?.status;
+  error.data = options?.data;
+  error.response = options?.response;
+
+  return error;
+};
+
+const getResponseMessage = (
+  response?: AxiosResponse<unknown>,
+  fallbackMessage = HTTP_CLIENT_MESSAGES.requestFailed,
+) => {
+  const responseMessage =
+    response?.data &&
+    typeof response.data === "object" &&
+    "message" in response.data
+      ? response.data.message
+      : undefined;
+
+  if (typeof responseMessage === "string" && responseMessage.trim()) {
+    return responseMessage;
+  }
+
+  return fallbackMessage;
+};
+
+const overrideErrorMessage = <T>(error: T): T => {
+  if (!axios.isAxiosError(error) || !error.response) {
+    return error;
+  }
+
+  error.message = getResponseMessage(error.response, error.message);
+
+  return error;
+};
+
+const formatAccessToken = (prefix: string, token: string) => {
+  const normalizedPrefix = prefix.trim();
+  return normalizedPrefix ? `${normalizedPrefix} ${token}` : token;
+};
+
+const shouldSkipRefresh = (
+  skipRefreshUrls: string[],
+  config?: InternalAxiosRequestConfig & RequestRetryState,
+) => {
+  const requestUrl = config?.url;
+
+  if (!requestUrl) {
+    return false;
+  }
+
+  return skipRefreshUrls.some((url) => requestUrl.includes(url));
+};
+
+export const createHttpClient = (options: HttpClientOptions): AxiosInstance => {
+  const refreshManager = new TokenRefreshManager();
+  const refreshEnabled = options.refreshAccessToken !== undefined;
+
+  const resolvedOptions: ResolvedHttpClientOptions = {
+    authFailureCodes: [],
+    accessTokenHeaderName: "Authorization",
+    accessTokenPrefix: "Bearer",
+    unauthorizedStatusCode: 401,
+    skipRefreshUrls: [],
+    isBusinessSuccess: () => true,
+    mapBusinessError: (response: AxiosResponse<unknown>) => {
+      return createHttpClientError(
+        getResponseMessage(
+          response,
+          HTTP_CLIENT_MESSAGES.businessRequestFailed,
+        ),
+        {
+          status: response.status,
+          data: response.data,
+          response,
+        },
+      );
+    },
+    shouldRefreshByResponseData: () => false,
+    onAuthFailure: () => {},
+    isRefreshFailure: (error: unknown) => {
+      if (!axios.isAxiosError(error) || !error.response) {
+        return false;
+      }
+
+      const status = error.response.status;
+      const data = error.response.data as { code?: number } | undefined;
+
+      if (status && status >= 500) {
+        return false;
+      }
+
+      return (
+        status === resolvedOptions.unauthorizedStatusCode ||
+        (data?.code !== undefined &&
+          resolvedOptions.authFailureCodes.includes(data.code))
+      );
+    },
+    ...options,
+  };
+  const instance = axios.create({
+    timeout: 15 * 1000,
+    ...resolvedOptions.axiosConfig,
+  });
+
+  const handleAuthFailure = async (error?: unknown) => {
+    await resolvedOptions.onAuthFailure(error);
+  };
+
+  const refreshAccessToken = async (): Promise<string> => {
+    const requestRefreshAccessToken = resolvedOptions.refreshAccessToken;
+
+    if (!refreshEnabled || !requestRefreshAccessToken) {
+      throw new Error(HTTP_CLIENT_MESSAGES.refreshDisabled);
+    }
+
+    return refreshManager.runRefresh(async () => {
+      try {
+        return await requestRefreshAccessToken();
+      } catch (error) {
+        const authError = resolvedOptions.isRefreshFailure(error)
+          ? createHttpClientError(HTTP_CLIENT_MESSAGES.refreshTokenExpired)
+          : overrideErrorMessage(error);
+
+        await handleAuthFailure(authError);
+        throw authError;
+      }
+    });
+  };
+
+  const retryAfterRefresh = async (
+    config: InternalAxiosRequestConfig & RequestRetryState,
+  ) => {
+    if (config._retry) {
+      const authError = createHttpClientError(
+        HTTP_CLIENT_MESSAGES.loginExpired,
+      );
+      await handleAuthFailure(authError);
+      throw authError;
+    }
+
+    config._retry = true;
+
+    try {
+      const newAccessToken = await refreshAccessToken();
+
+      config.headers = config.headers ?? {};
+      config.headers[resolvedOptions.accessTokenHeaderName] = formatAccessToken(
+        resolvedOptions.accessTokenPrefix,
+        newAccessToken,
+      );
+
+      return await instance.request(config);
+    } catch (error) {
+      throw overrideErrorMessage(error);
+    }
+  };
+
+  instance.interceptors.request.use(
+    async (config: InternalAxiosRequestConfig & RequestRetryState) => {
+      const currentAuthorization =
+        config.headers?.[resolvedOptions.accessTokenHeaderName];
+
+      if (currentAuthorization) {
+        return config;
+      }
+
+      const accessToken = await resolvedOptions.getAccessToken();
+      if (!accessToken) return config;
+
+      config.headers = config.headers ?? {};
+      config.headers[resolvedOptions.accessTokenHeaderName] = formatAccessToken(
+        resolvedOptions.accessTokenPrefix,
+        accessToken,
+      );
+
+      return config;
+    },
+    (error) => Promise.reject(error),
+  );
+
+  instance.interceptors.response.use(
+    async (response) => {
+      const config = response.config as InternalAxiosRequestConfig &
+        RequestRetryState;
+
+      if (resolvedOptions.shouldRefreshByResponseData(response)) {
+        if (
+          !refreshEnabled ||
+          shouldSkipRefresh(resolvedOptions.skipRefreshUrls, config)
+        ) {
+          return response;
+        }
+
+        return retryAfterRefresh(config);
+      }
+
+      if (!resolvedOptions.isBusinessSuccess(response)) {
+        throw resolvedOptions.mapBusinessError(response);
+      }
+
+      return response;
+    },
+    async (error: AxiosError) => {
+      const config = error.config as
+        | (InternalAxiosRequestConfig & RequestRetryState)
+        | undefined;
+
+      overrideErrorMessage(error);
+
+      if (!config) {
+        return Promise.reject(error);
+      }
+
+      const status = error.response?.status;
+
+      if (status === resolvedOptions.unauthorizedStatusCode) {
+        if (
+          !refreshEnabled ||
+          shouldSkipRefresh(resolvedOptions.skipRefreshUrls, config)
+        ) {
+          await handleAuthFailure(error);
+
+          return Promise.reject(error);
+        }
+
+        try {
+          return await retryAfterRefresh(config);
+        } catch (refreshError) {
+          return Promise.reject(refreshError);
+        }
+      }
+
+      return Promise.reject(error);
+    },
+  );
+
+  return instance;
+};

--- a/apps/web/src/services/api/http-factory/token-refresh-manager.ts
+++ b/apps/web/src/services/api/http-factory/token-refresh-manager.ts
@@ -1,0 +1,17 @@
+export class TokenRefreshManager {
+  private refreshingPromise: Promise<string> | null = null;
+
+  async runRefresh(task: () => Promise<string>): Promise<string> {
+    if (!this.refreshingPromise) {
+      this.refreshingPromise = (async () => {
+        try {
+          return await task();
+        } finally {
+          this.refreshingPromise = null;
+        }
+      })();
+    }
+
+    return this.refreshingPromise;
+  }
+}

--- a/apps/web/src/services/api/http-factory/token-refresh-manager.ts
+++ b/apps/web/src/services/api/http-factory/token-refresh-manager.ts
@@ -1,7 +1,9 @@
-export class TokenRefreshManager {
-  private refreshingPromise: Promise<string> | null = null;
+import type { AccessTokenResult } from "./types";
 
-  async runRefresh(task: () => Promise<string>): Promise<string> {
+export class TokenRefreshManager {
+  private refreshingPromise: Promise<AccessTokenResult> | null = null;
+
+  async runRefresh(task: () => Promise<AccessTokenResult>): Promise<AccessTokenResult> {
     if (!this.refreshingPromise) {
       this.refreshingPromise = (async () => {
         try {

--- a/apps/web/src/services/api/http-factory/types.ts
+++ b/apps/web/src/services/api/http-factory/types.ts
@@ -1,0 +1,106 @@
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+
+/**
+ * 请求内部状态。
+ */
+export interface RequestRetryState {
+  _retry?: boolean;
+}
+
+/**
+ * 创建 HTTP 客户端时可传入的配置。
+ */
+export interface HttpClientOptions {
+  /**
+   * 透传给 axios.create 的初始化配置。
+   */
+  axiosConfig: AxiosRequestConfig;
+
+  /**
+   * access token 注入到请求头时使用的字段名。
+   * 默认 `Authorization`。
+   */
+  accessTokenHeaderName?: string;
+
+  /**
+   * access token 的前缀。
+   * 默认 `Bearer`。
+   */
+  accessTokenPrefix?: string;
+
+  /**
+   * 触发刷新流程的 HTTP 状态码。
+   * 默认 `401`。
+   */
+  unauthorizedStatusCode?: number;
+
+  /**
+   * 业务状态码中，用于识别鉴权失败的 code 列表。
+   */
+  authFailureCodes?: number[];
+
+  /**
+   * 不触发 refresh token 流程的请求 URL 列表。
+   */
+  skipRefreshUrls?: string[];
+
+  /**
+   * 获取当前 access token。
+   */
+  getAccessToken: () => string | null | Promise<string | null>;
+
+  /**
+   * 自定义刷新逻辑，必须返回最终要用于重试请求的 access token。
+   */
+  refreshAccessToken?: () => string | Promise<string>;
+
+  /**
+   * 登录失效后的统一收尾回调。
+   */
+  onAuthFailure?: (error?: unknown) => void | Promise<void>;
+
+  /**
+   * 自定义业务响应是否成功的判定逻辑。
+   */
+  isBusinessSuccess?: (response: AxiosResponse<unknown>) => boolean;
+
+  /**
+   * 将业务失败响应映射为错误对象。
+   */
+  mapBusinessError?: (response: AxiosResponse<unknown>) => Error;
+
+  /**
+   * 通过业务响应内容判断是否需要刷新 token。
+   */
+  shouldRefreshByResponseData?: (response: AxiosResponse<unknown>) => boolean;
+
+  /**
+   * 判断刷新 token 请求本身是否已经失败到需要退出登录。
+   */
+  isRefreshFailure?: (error: unknown) => boolean;
+}
+
+/**
+ * 补齐默认值后的完整配置类型，仅供内部使用。
+ */
+type ResolvedHttpClientOptionKeys =
+  | "authFailureCodes"
+  | "accessTokenHeaderName"
+  | "accessTokenPrefix"
+  | "unauthorizedStatusCode"
+  | "isBusinessSuccess"
+  | "mapBusinessError"
+  | "skipRefreshUrls"
+  | "shouldRefreshByResponseData"
+  | "onAuthFailure"
+  | "isRefreshFailure";
+
+type ResolvedHttpClientOptionOverrides = {
+  [K in ResolvedHttpClientOptionKeys]-?: NonNullable<HttpClientOptions[K]>;
+};
+
+export type ResolvedHttpClientOptions = Omit<
+  HttpClientOptions,
+  ResolvedHttpClientOptionKeys
+> &
+  ResolvedHttpClientOptionOverrides;

--- a/apps/web/src/services/api/http-factory/types.ts
+++ b/apps/web/src/services/api/http-factory/types.ts
@@ -1,6 +1,23 @@
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 
 /**
+ * token 详细信息，用于主动刷新判断。
+ */
+export interface AccessTokenDetail {
+  token: string;
+  expiresAt: Date | string;
+  /**
+   * 提前刷新的毫秒数，默认 60000（1 分钟）。
+   */
+  refreshBufferMs?: number;
+}
+
+/**
+ * getAccessToken 的返回值类型，兼容旧版纯字符串返回。
+ */
+export type AccessTokenResult = string | AccessTokenDetail | null;
+
+/**
  * 请求内部状态。
  */
 export interface RequestRetryState {
@@ -46,8 +63,11 @@ export interface HttpClientOptions {
 
   /**
    * 获取当前 access token。
+   *
+   * 返回 `string` 时仅注入 token，不做主动刷新判断。
+   * 返回 `AccessTokenDetail` 时，会在 token 即将过期前主动触发刷新。
    */
-  getAccessToken: () => string | null | Promise<string | null>;
+  getAccessToken: () => AccessTokenResult | Promise<AccessTokenResult>;
 
   /**
    * 自定义刷新逻辑，必须返回最终要用于重试请求的 access token。

--- a/apps/web/src/services/api/http-factory/types.ts
+++ b/apps/web/src/services/api/http-factory/types.ts
@@ -26,8 +26,11 @@ export interface RequestRetryState {
 
 /**
  * 创建 HTTP 客户端时可传入的配置。
+ *
+ * @typeParam T - getAccessToken / refreshAccessToken 的统一返回类型，
+ *   默认为 `AccessTokenResult`。当 T 为 `AccessTokenDetail` 时启用主动刷新。
  */
-export interface HttpClientOptions {
+export interface HttpClientOptions<T extends AccessTokenResult = AccessTokenResult> {
   /**
    * 透传给 axios.create 的初始化配置。
    */
@@ -67,12 +70,13 @@ export interface HttpClientOptions {
    * 返回 `string` 时仅注入 token，不做主动刷新判断。
    * 返回 `AccessTokenDetail` 时，会在 token 即将过期前主动触发刷新。
    */
-  getAccessToken: () => AccessTokenResult | Promise<AccessTokenResult>;
+  getAccessToken: () => T | Promise<T>;
 
   /**
-   * 自定义刷新逻辑，必须返回最终要用于重试请求的 access token。
+   * 自定义刷新逻辑，返回类型必须与 getAccessToken 一致。
+   * 返回 AccessTokenDetail 时可携带新的过期时间，避免后续请求因旧过期时间重复触发刷新。
    */
-  refreshAccessToken?: () => string | Promise<string>;
+  refreshAccessToken?: () => T | Promise<T>;
 
   /**
    * 登录失效后的统一收尾回调。
@@ -115,12 +119,12 @@ type ResolvedHttpClientOptionKeys =
   | "onAuthFailure"
   | "isRefreshFailure";
 
-type ResolvedHttpClientOptionOverrides = {
-  [K in ResolvedHttpClientOptionKeys]-?: NonNullable<HttpClientOptions[K]>;
+type ResolvedHttpClientOptionOverrides<T extends AccessTokenResult> = {
+  [K in ResolvedHttpClientOptionKeys]-?: NonNullable<HttpClientOptions<T>[K]>;
 };
 
-export type ResolvedHttpClientOptions = Omit<
-  HttpClientOptions,
+export type ResolvedHttpClientOptions<T extends AccessTokenResult = AccessTokenResult> = Omit<
+  HttpClientOptions<T>,
   ResolvedHttpClientOptionKeys
 > &
-  ResolvedHttpClientOptionOverrides;
+  ResolvedHttpClientOptionOverrides<T>;

--- a/apps/web/src/services/api/new-http.ts
+++ b/apps/web/src/services/api/new-http.ts
@@ -1,0 +1,29 @@
+import { RefreshToken } from "@/services/api/refresh-token";
+import { useUserStore } from "@/stores/user";
+import { createHttpClient } from "./http-factory";
+
+const NO_AUTO_REFRESH_API_LIST = ["/auth/login", "/auth/refresh-token"];
+
+const newHttp = createHttpClient({
+  axiosConfig: {
+    baseURL: "/api",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    timeout: 1000 * 10,
+  },
+  getAccessToken: () => {
+    return useUserStore.getState().jwtToken?.accessToken ?? null;
+  },
+  refreshAccessToken: async () => {
+    const { accessToken } = await RefreshToken();
+
+    return accessToken;
+  },
+  onAuthFailure: () => {
+    useUserStore.getState().logout();
+  },
+  skipRefreshUrls: NO_AUTO_REFRESH_API_LIST,
+});
+
+export default newHttp;

--- a/apps/web/src/services/api/new-http.ts
+++ b/apps/web/src/services/api/new-http.ts
@@ -13,12 +13,21 @@ const newHttp = createHttpClient({
     timeout: 1000 * 10,
   },
   getAccessToken: () => {
-    return useUserStore.getState().jwtToken?.accessToken ?? null;
+    const jwtToken = useUserStore.getState().jwtToken;
+    if (!jwtToken?.accessToken) return null;
+
+    return {
+      token: jwtToken.accessToken,
+      expiresAt: new Date(jwtToken.expiresAt),
+    };
   },
   refreshAccessToken: async () => {
-    const { accessToken } = await RefreshToken();
+    const { accessToken, expiresAt } = await RefreshToken();
 
-    return accessToken;
+    return {
+      token: accessToken,
+      expiresAt,
+    };
   },
   onAuthFailure: () => {
     useUserStore.getState().logout();

--- a/apps/web/src/services/api/permission.ts
+++ b/apps/web/src/services/api/permission.ts
@@ -1,6 +1,6 @@
 import type { IUpdatePermissionDto } from "../dtos/permission";
 import type { IPermission } from "../types/permission";
-import http from "./http";
+import http from "./new-http";
 
 /**
  * 获取所有权限

--- a/apps/web/src/services/api/role.ts
+++ b/apps/web/src/services/api/role.ts
@@ -1,6 +1,6 @@
 import type { ICreateRoleDto, IUpdateRoleDto } from "../dtos/role";
 import type { IRole } from "../types/role";
-import http from "./http";
+import http from "./new-http";
 
 /**
  * 获取所有角色

--- a/apps/web/src/services/api/user.ts
+++ b/apps/web/src/services/api/user.ts
@@ -6,7 +6,7 @@ import type {
   IUpdateUserSpecialRolesDto,
 } from "../dtos/user";
 import type { IUser } from "../types/user";
-import http from "./http";
+import http from "./new-http";
 
 /**
  * 创建用户

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -24,7 +24,6 @@
     "noUncheckedSideEffectImports": true,
 
     /* Paths */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,6 +837,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.7.1":
   version: 1.8.1
   resolution: "@emnapi/core@npm:1.8.1"
@@ -844,6 +854,15 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.1.0"
     tslib: "npm:^2.4.0"
   checksum: 10c0/2c242f4b49779bac403e1cbcc98edacdb1c8ad36562408ba9a20663824669e930bc8493be46a2522d9dc946b8d96cd7073970bae914928c7671b5221c85b432e
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
   languageName: node
   linkType: hard
 
@@ -862,6 +881,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/e6d54bf2b1e64cdd83d2916411e44e579b6ae35d5def0dea61a3c452d9921373044dff32a8b8473ae60c80692bdc39323e98b96a3f3d87ba6886b24dd0ef7ca1
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
   languageName: node
   linkType: hard
 
@@ -1926,11 +1954,13 @@ __metadata:
     "@nestjs/mapped-types": "npm:2.1.0"
     "@nestjs/passport": "npm:^11.0.5"
     "@nestjs/platform-express": "npm:11.1.0"
+    "@nestjs/platform-socket.io": "npm:^11.1.19"
     "@nestjs/schematics": "npm:^11.0.5"
     "@nestjs/serve-static": "npm:^5.0.3"
     "@nestjs/swagger": "npm:11.2.0"
     "@nestjs/testing": "npm:11.1.0"
     "@nestjs/typeorm": "npm:^11.0.0"
+    "@nestjs/websockets": "npm:^11.1.19"
     "@swc/cli": "npm:^0.7.8"
     "@swc/core": "npm:^1.12.14"
     "@types/cookie-parser": "npm:^1.4.9"
@@ -1993,7 +2023,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^5.1.1"
     antd: "npm:^5.29.1"
-    axios: "npm:^1.13.2"
+    axios: "npm:^1.15.2"
     babel-plugin-react-compiler: "npm:^1.0.0"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
@@ -2011,6 +2041,7 @@ __metadata:
     react-dom: "npm:^19.2.0"
     react-hook-form: "npm:^7.66.1"
     react-router: "npm:^7.9.6"
+    socket.io-client: "npm:^4.8.3"
     sonner: "npm:^2.0.7"
     tailwind-merge: "npm:^3.4.0"
     tailwindcss: "npm:^4.1.17"
@@ -2018,6 +2049,7 @@ __metadata:
     typescript: "npm:^5.9.3"
     typescript-eslint: "npm:^8.47.0"
     vite: "npm:^7.2.2"
+    vitest: "npm:^4.1.5"
     zod: "npm:^4.1.12"
     zustand: "npm:^5.0.8"
   languageName: unknown
@@ -2213,6 +2245,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
 "@nestjs/cli@npm:^11.0.7":
   version: 11.0.16
   resolution: "@nestjs/cli@npm:11.0.16"
@@ -2369,6 +2413,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/platform-socket.io@npm:^11.1.19":
+  version: 11.1.19
+  resolution: "@nestjs/platform-socket.io@npm:11.1.19"
+  dependencies:
+    socket.io: "npm:4.8.3"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/websockets": ^11.0.0
+    rxjs: ^7.1.0
+  checksum: 10c0/bfc772db0305593939ba8724b9576c1c5a7c1c601cd2c2be425bdb9895a1c1321ee77de84b85554370d8f7b027576a4dbff15508488de464c362314ddffcfdf9
+  languageName: node
+  linkType: hard
+
 "@nestjs/schematics@npm:^11.0.1, @nestjs/schematics@npm:^11.0.5":
   version: 11.0.9
   resolution: "@nestjs/schematics@npm:11.0.9"
@@ -2466,6 +2524,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/websockets@npm:^11.1.19":
+  version: 11.1.19
+  resolution: "@nestjs/websockets@npm:11.1.19"
+  dependencies:
+    iterare: "npm:1.2.1"
+    object-hash: "npm:3.0.0"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/core": ^11.0.0
+    "@nestjs/platform-socket.io": ^11.0.0
+    reflect-metadata: ^0.1.12 || ^0.2.0
+    rxjs: ^7.1.0
+  peerDependenciesMeta:
+    "@nestjs/platform-socket.io":
+      optional: true
+  checksum: 10c0/3a6eb3c41e7af3143b6429e779c5d73c93685e6d84719433e4d0beb09e0df15c66e5a8ae3ee621934699e23a905309adc8c475286051959628f1f43b29fc696a
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:^1.1.5":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
@@ -2503,6 +2581,13 @@ __metadata:
   bin:
     opencollective: bin/opencollective.js
   checksum: 10c0/ef2835d8635d2928152eff8b5a1ec42c145e2ab00cb02ff4bb61f0a6f5528afc9b169c06c32308c783779fe26855ebc67419743046caa80e582e814cff73187d
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-project/types@npm:0.127.0"
+  checksum: 10c0/52c0947ac64a9ca119fe971f947e784a35ecd14a072fa3f542a58a5f6c42010b53f2bf92731e39b9899b83c990a9517bbd29d1e5a5b7b489e52616685c6a9278
   languageName: node
   linkType: hard
 
@@ -3330,10 +3415,126 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.17"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/pluginutils@npm:1.0.0-beta.53":
   version: 1.0.0-beta.53
   resolution: "@rolldown/pluginutils@npm:1.0.0-beta.53"
   checksum: 10c0/e8b0a7eb76be22f6f103171f28072de821525a4e400454850516da91a7381957932ff0ce495f227bcb168e86815788b0c1d249ca9e34dca366a82c8825b714ce
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.17"
+  checksum: 10c0/5e840b20cc531910c093c1ca36e550952cf4936465a50d89f0a98fc9d0dfd7d319d06a10a5f4376209d89e9bf4d60af6cc8363ebf0dcc5e60842f7fef438b2f0
   languageName: node
   linkType: hard
 
@@ -3652,10 +3853,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@socket.io/component-emitter@npm:~3.1.0":
+  version: 3.1.2
+  resolution: "@socket.io/component-emitter@npm:3.1.2"
+  checksum: 10c0/c4242bad66f67e6f7b712733d25b43cbb9e19a595c8701c3ad99cbeb5901555f78b095e24852f862fffb43e96f1d8552e62def885ca82ae1bb05da3668fd87d7
+  languageName: node
+  linkType: hard
+
 "@sqltools/formatter@npm:^1.2.5":
   version: 1.2.5
   resolution: "@sqltools/formatter@npm:1.2.5"
   checksum: 10c0/4b4fa62b8cd4880784b71cc5edd4a13da04fda0a915c14282765a8ec1a900a495e69b322704413e2052d221b5646d9fb0e20e87911f9a8f438f33180eecb11a4
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
@@ -4122,6 +4337,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:*":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
@@ -4156,6 +4381,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cors@npm:^2.8.12":
+  version: 2.8.19
+  resolution: "@types/cors@npm:2.8.19"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b5dd407040db7d8aa1bd36e79e5f3f32292f6b075abc287529e9f48df1a25fda3e3799ba30b4656667ffb931d3b75690c1d6ca71e39f7337ea6dfda8581916d0
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.7":
   version: 3.7.7
   resolution: "@types/eslint-scope@npm:3.7.7"
@@ -4176,7 +4417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -4346,6 +4587,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=10.0.0":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^22.19.1":
   version: 22.19.7
   resolution: "@types/node@npm:22.19.7"
@@ -4493,6 +4743,15 @@ __metadata:
   version: 0.0.21
   resolution: "@types/web-bluetooth@npm:0.0.21"
   checksum: 10c0/5f47c5ec452ca31e6a9b44c8aaa54b66c4f57d4aca00166c45902a3883139580e14b254b774172ff982ba4458cc444b5aa59bb4573c2fd34562cfa599721f8e4
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.12":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/61aff1129143fcc4312f083bc9e9e168aa3026b7dd6e70796276dcfb2c8211c4292603f9c4864fae702f2ed86e4abd4d38aa421831c2fd7f856c931a481afbab
   languageName: node
   linkType: hard
 
@@ -4679,6 +4938,88 @@ __metadata:
     vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     vue: ^3.2.25
   checksum: 10c0/53fb6e4bbeab8703b05c7bb8ee80206eba19f7edfa4672c4ff577d3021af4bed492ca70faf7985e3f7c5a7938f43e4232d63af0905b67bade997a81d7b1d09bd
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/expect@npm:4.1.5"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/5184682304db471aa20024c1154210ad3d6d590afb61646201ce1a15297259f9a35f92f8fad4435bc8a82135e307ddd27c8495f72417d72d9aa139eb281d9e06
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/mocker@npm:4.1.5"
+  dependencies:
+    "@vitest/spy": "npm:4.1.5"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/bcfe97700476130933c7ea33fa670c8d2768a81de5325ce407f901e55c2f66cabbb88a7b6cffb46ddf33dff7d8fc209d769fb298f568e310fbeead9b36f6fdb9
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/pretty-format@npm:4.1.5"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/42b5e9b75e87c0a884d36bee364e2d07ee45e96f413377737a74993e077d90c3a12aa36743855aee5e4e28b78fae20e3e6de5eef8d5344b9aba2bc1e1d5537a1
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/runner@npm:4.1.5"
+  dependencies:
+    "@vitest/utils": "npm:4.1.5"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/6a03b313a121155f6dd9e32eeb103c0e12440f586bc4ba1f0d77444e44c6df4652a44443718552037463115635b8378e11f35902d90ce1326f77743219fca056
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/snapshot@npm:4.1.5"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e11bf50d06702331290750a40eaef86078c108df3cd9a52bb1be7b84250048790163f36827525be6a383a4bb1994fc35e6d0c24239a41688b0bb68a1d15d172f
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/spy@npm:4.1.5"
+  checksum: 10c0/fda6b1ee0a2fec1a152d8041aba7a79744c3876863b244d1ed406d02b36e8ccc997edb2e3963d1027d728d3dc5a33813e11bef53a0a14fc7de4de5e721d0f591
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/utils@npm:4.1.5"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.5"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/72409717e68018e5fe42fa173cc4eff6def8c35bd52013f86ddb414cd28d73fcc425ac62968e01a52371b3fd5a7a775536283d2f1d64432753f628712a6a4908
   languageName: node
   linkType: hard
 
@@ -5204,6 +5545,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:~1.3.4":
+  version: 1.3.8
+  resolution: "accepts@npm:1.3.8"
+  dependencies:
+    mime-types: "npm:~2.1.34"
+    negotiator: "npm:0.6.3"
+  checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
+  languageName: node
+  linkType: hard
+
 "acorn-import-phases@npm:^1.0.3":
   version: 1.0.4
   resolution: "acorn-import-phases@npm:1.0.4"
@@ -5544,6 +5895,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "async-function@npm:^1.0.0":
   version: 1.0.0
   resolution: "async-function@npm:1.0.0"
@@ -5574,14 +5932,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.13.2":
-  version: 1.13.3
-  resolution: "axios@npm:1.13.3"
+"axios@npm:^1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
   dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10c0/86f0770624d9f14a3f8f8738c8b8f7f7fbb7b0d4ad38757db1de2d71007a0311bc597661c5ff4b4a9ee6350c6956a7282e3a281fcdf7b5b32054e35a8801e2ce
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/4eeae0feeaa7fdc1ef24f81f8b378fdadedf4aebdd6bf224484675160f8744cf17b9b0d1c215279979940f7e8ce463beffa2f713099612e428eac238515c81d5
   languageName: node
   linkType: hard
 
@@ -5708,6 +6066,13 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"base64id@npm:2.0.0, base64id@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "base64id@npm:2.0.0"
+  checksum: 10c0/6919efd237ed44b9988cbfc33eca6f173a10e810ce50292b271a1a421aac7748ef232a64d1e6032b08f19aae48dce6ee8f66c5ae2c9e5066c82b884861d4d453
   languageName: node
   linkType: hard
 
@@ -5999,6 +6364,13 @@ __metadata:
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
   checksum: 10c0/3939b1664390174484322bc3f45b798462e6c07ee6384cb3d645e0aa2f318502d174845198c1561930e1d431087f74cf1fe291ae9a4722821a9f4ba67e574350
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -6433,7 +6805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.2, cookie@npm:^0.7.1":
+"cookie@npm:0.7.2, cookie@npm:^0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -6486,6 +6858,16 @@ __metadata:
     object-assign: "npm:^4"
     vary: "npm:^1"
   checksum: 10c0/373702b7999409922da80de4a61938aabba6929aea5b6fd9096fefb9e8342f626c0ebd7507b0e8b0b311380744cc985f27edebc0a26e0ddb784b54e1085de761
+  languageName: node
+  linkType: hard
+
+"cors@npm:~2.8.5":
+  version: 2.8.6
+  resolution: "cors@npm:2.8.6"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/ab2bc57b8af8ef8476682a59647f7c55c1a7d406b559ac06119aa1c5f70b96d35036864d197b24cf86e228e4547231088f1f94ca05061dbb14d89cc0bc9d4cab
   languageName: node
   linkType: hard
 
@@ -6604,7 +6986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:^4.4.0, debug@npm:^4.4.3, debug@npm:~4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -6891,6 +7273,44 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
+"engine.io-client@npm:~6.6.1":
+  version: 6.6.4
+  resolution: "engine.io-client@npm:6.6.4"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.18.3"
+    xmlhttprequest-ssl: "npm:~2.1.1"
+  checksum: 10c0/d90bc32d614f67db9c198d1c26a787529f3038a7429c75e677f5495938cc45f9e89d435e8860bcfcc01db410e21d2f245b914f2fcbdb03ffd50d30f2aeec5143
+  languageName: node
+  linkType: hard
+
+"engine.io-parser@npm:~5.2.1":
+  version: 5.2.3
+  resolution: "engine.io-parser@npm:5.2.3"
+  checksum: 10c0/ed4900d8dbef470ab3839ccf3bfa79ee518ea8277c7f1f2759e8c22a48f64e687ea5e474291394d0c94f84054749fd93f3ef0acb51fa2f5f234cc9d9d8e7c536
+  languageName: node
+  linkType: hard
+
+"engine.io@npm:~6.6.0":
+  version: 6.6.7
+  resolution: "engine.io@npm:6.6.7"
+  dependencies:
+    "@types/cors": "npm:^2.8.12"
+    "@types/node": "npm:>=10.0.0"
+    "@types/ws": "npm:^8.5.12"
+    accepts: "npm:~1.3.4"
+    base64id: "npm:2.0.0"
+    cookie: "npm:~0.7.2"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.4.1"
+    engine.io-parser: "npm:~5.2.1"
+    ws: "npm:~8.18.3"
+  checksum: 10c0/cde9cbadf39b0ccc5399ac7d64fc2802bd93300672b2e6f86ca96a6f0c5be40f6f512af8f0709d7f789b455a7b9af2a1fc06407dcad2082fa1f150591b6358e2
   languageName: node
   linkType: hard
 
@@ -7304,6 +7724,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -7362,6 +7791,13 @@ __metadata:
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
   checksum: 10c0/71d2ad9b36bc25bb8b104b17e830b40a08989be7f7d100b13269aaae7c3784c3e6e1e88a797e9e87523993a25ba27c8958959a554535370672cfb4d824af8989
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -7654,13 +8090,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.15.11":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 
@@ -7713,7 +8149,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
   version: 4.0.5
   resolution: "form-data@npm:4.0.5"
   dependencies:
@@ -9264,9 +9700,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-android-arm64@npm:1.32.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-darwin-arm64@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-darwin-arm64@npm:1.30.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -9278,9 +9728,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "lightningcss-freebsd-x64@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-freebsd-x64@npm:1.30.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -9292,9 +9756,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-arm64-gnu@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-linux-arm64-gnu@npm:1.30.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9306,9 +9784,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-x64-gnu@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-linux-x64-gnu@npm:1.30.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9320,6 +9812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-x64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-arm64-msvc@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-win32-arm64-msvc@npm:1.30.2"
@@ -9327,9 +9826,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-win32-arm64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-x64-msvc@npm:1.30.2":
   version: 1.30.2
   resolution: "lightningcss-win32-x64-msvc@npm:1.30.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -9374,6 +9887,49 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10c0/5c0c73a33946dab65908d5cd1325df4efa290efb77f940b60f40448b5ab9a87d3ea665ef9bcf00df4209705050ecf2f7ecc649f44d6dfa5905bb50f15717e78d
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss@npm:1.32.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.32.0"
+    lightningcss-darwin-arm64: "npm:1.32.0"
+    lightningcss-darwin-x64: "npm:1.32.0"
+    lightningcss-freebsd-x64: "npm:1.32.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
+    lightningcss-linux-arm64-gnu: "npm:1.32.0"
+    lightningcss-linux-arm64-musl: "npm:1.32.0"
+    lightningcss-linux-x64-gnu: "npm:1.32.0"
+    lightningcss-linux-x64-musl: "npm:1.32.0"
+    lightningcss-win32-arm64-msvc: "npm:1.32.0"
+    lightningcss-win32-x64-msvc: "npm:1.32.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
   languageName: node
   linkType: hard
 
@@ -9854,7 +10410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -10119,6 +10675,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"negotiator@npm:0.6.3":
+  version: 0.6.3
+  resolution: "negotiator@npm:0.6.3"
+  checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
+  languageName: node
+  linkType: hard
+
 "negotiator@npm:^1.0.0":
   version: 1.0.0
   resolution: "negotiator@npm:1.0.0"
@@ -10254,10 +10817,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-hash@npm:3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: 10c0/a06844537107b960c1c8b96cd2ac8592a265186bfa0f6ccafe0d34eabdb526f6fa81da1f37c43df7ed13b12a4ae3457a16071603bcd39d8beddb5f08c37b0f47
+  languageName: node
+  linkType: hard
+
 "object-inspect@npm:^1.13.3":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
+  languageName: node
+  linkType: hard
+
+"obug@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "obug@npm:2.1.1"
+  checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
   languageName: node
   linkType: hard
 
@@ -10569,6 +11146,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "pause@npm:0.0.1":
   version: 0.0.1
   resolution: "pause@npm:0.0.1"
@@ -10699,6 +11283,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
 "pidtree@npm:^0.6.0":
   version: 0.6.0
   resolution: "pidtree@npm:0.6.0"
@@ -10747,6 +11338,17 @@ __metadata:
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
   checksum: 10c0/c810983414142071da1d644662ce4caebce890203eb2bc7bf119f37f3fe5796226e117e6cca146b521921fa6531072674174a3325066ac66fce089a53e1e5196
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 
@@ -10942,10 +11544,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: 10c0/ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 
@@ -11841,6 +12443,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "rolldown@npm:1.0.0-rc.17"
+  dependencies:
+    "@oxc-project/types": "npm:=0.127.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.17"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 10c0/bb99abc62ece4e34edd06d2b8eb9ffb7194dc2f0465a4329bb106cbde3006a10f1575e3580b198b793341109a2109581aed623c537c12b0c3a4ba0d72169b2fb
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.43.0":
   version: 4.56.0
   resolution: "rollup@npm:4.56.0"
@@ -12229,6 +12889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -12271,6 +12938,53 @@ __metadata:
   version: 4.2.0
   resolution: "smart-buffer@npm:4.2.0"
   checksum: 10c0/a16775323e1404dd43fabafe7460be13a471e021637bc7889468eb45ce6a6b207261f454e4e530a19500cc962c4cc5348583520843b363f4193cee5c00e1e539
+  languageName: node
+  linkType: hard
+
+"socket.io-adapter@npm:~2.5.2":
+  version: 2.5.6
+  resolution: "socket.io-adapter@npm:2.5.6"
+  dependencies:
+    debug: "npm:~4.4.1"
+    ws: "npm:~8.18.3"
+  checksum: 10c0/2af9827c3e8e2a445d7d1523f7ad4fcc37009da44f72042e8a9af27e4caf29fe0a34de6771a6e9971a0ff8d527631fe25b80230ff6c42c045e2913f0ac308059
+  languageName: node
+  linkType: hard
+
+"socket.io-client@npm:^4.8.3":
+  version: 4.8.3
+  resolution: "socket.io-client@npm:4.8.3"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+    engine.io-client: "npm:~6.6.1"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/76c0d86de0b636d0bf5011cf3425212c900f43dac632db6eb493816920cd035af7ddd92fea9a106b45eb347405953c0414eb3a5d465b180215e46fc8b61420b3
+  languageName: node
+  linkType: hard
+
+"socket.io-parser@npm:~4.2.4":
+  version: 4.2.6
+  resolution: "socket.io-parser@npm:4.2.6"
+  dependencies:
+    "@socket.io/component-emitter": "npm:~3.1.0"
+    debug: "npm:~4.4.1"
+  checksum: 10c0/ba0a0b541b0a8e9d02b45c04c4c93a02331be5ea3478073c65bb9ff87032f12469c9adb309728eb90c0a352618d645ab88999c167a11c783cac861d7fd35c9d1
+  languageName: node
+  linkType: hard
+
+"socket.io@npm:4.8.3":
+  version: 4.8.3
+  resolution: "socket.io@npm:4.8.3"
+  dependencies:
+    accepts: "npm:~1.3.4"
+    base64id: "npm:~2.0.0"
+    cors: "npm:~2.8.5"
+    debug: "npm:~4.4.1"
+    engine.io: "npm:~6.6.0"
+    socket.io-adapter: "npm:~2.5.2"
+    socket.io-parser: "npm:~4.2.4"
+  checksum: 10c0/1f7c4118cdbcb346e63db9d8fd657c3dc5caf148404762ed98ac14c4e7b74984a65fe51657bfe1696adcf7c168d1a3aad4a26b52864ce8491556f38218598f0b
   languageName: node
   linkType: hard
 
@@ -12424,10 +13138,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -12832,10 +13560,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.0.0":
   version: 1.0.2
   resolution: "tinyexec@npm:1.0.2"
   checksum: 10c0/1261a8e34c9b539a9aae3b7f0bb5372045ff28ee1eba035a2a059e532198fe1a182ec61ac60fa0b4a4129f0c4c4b1d2d57355b5cb9aa2d17ac9454ecace502ee
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "tinyexec@npm:1.1.2"
+  checksum: 10c0/9e0ef6c001ce54688cf16833a02f70a339276219ca947b88930b124267de2cffc764ff44e87e7369384b1d75ab63491465412cbbdf06f2437956b9ab66ab4491
   languageName: node
   linkType: hard
 
@@ -12846,6 +13588,23 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -13285,6 +14044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
+  languageName: node
+  linkType: hard
+
 "unicorn-magic@npm:^0.1.0":
   version: 0.1.0
   resolution: "unicorn-magic@npm:0.1.0"
@@ -13510,6 +14276,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.0.10
+  resolution: "vite@npm:8.0.10"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.10"
+    rolldown: "npm:1.0.0-rc.17"
+    tinyglobby: "npm:^0.2.16"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.1.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/92188b82654f856dbe562a1b679de695bb6ca18c0f43c4c276f84a869fb78e22dedb7c2df83b5617d6afdca979c059d654b5f61a0936a45f49917f352b9325ca
+  languageName: node
+  linkType: hard
+
 "vite@npm:^7.2.2":
   version: 7.3.1
   resolution: "vite@npm:7.3.1"
@@ -13601,6 +14424,74 @@ __metadata:
   bin:
     vitepress: bin/vitepress.js
   checksum: 10c0/d60f5568bfdf008d1b49902b5717e2b267a2c024fbce9397ae97ae4a655c99e78a96d0a57fa9457b893a2e019630ae216e625b21290c21826bcb2a23c13fc5e4
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "vitest@npm:4.1.5"
+  dependencies:
+    "@vitest/expect": "npm:4.1.5"
+    "@vitest/mocker": "npm:4.1.5"
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/runner": "npm:4.1.5"
+    "@vitest/snapshot": "npm:4.1.5"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.5
+    "@vitest/browser-preview": 4.1.5
+    "@vitest/browser-webdriverio": 4.1.5
+    "@vitest/coverage-istanbul": 4.1.5
+    "@vitest/coverage-v8": 4.1.5
+    "@vitest/ui": 4.1.5
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/196eaf5e95b45a3f6d3001a2408d7dc6f146c29c873ed4e42e1ad4c9327122934fb3793a12b6ce3b7c25d355e738b20123acc0894ce30358c3370b15f4bd0865
   languageName: node
   linkType: hard
 
@@ -13739,6 +14630,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -13811,6 +14714,28 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     signal-exit: "npm:^3.0.7"
   checksum: 10c0/a2c282c95ef5d8e1c27b335ae897b5eca00e85590d92a3fd69a437919b7b93ff36a69ea04145da55829d2164e724bc62202cdb5f4b208b425aba0807889375c7
+  languageName: node
+  linkType: hard
+
+"ws@npm:~8.18.3":
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest-ssl@npm:~2.1.1":
+  version: 2.1.2
+  resolution: "xmlhttprequest-ssl@npm:2.1.2"
+  checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] feat
- [ ] fix
- [x] refactor
- [ ] chore
- [ ] style
- [ ] docs
- [ ] test

#### 🔀 变更说明 | Description of Change

新增 `http-factory` 模块，提供可复用的 HTTP 客户端工厂函数，替代各 API 模块中重复的 axios 封装逻辑。

**核心能力：**

- **Token 自动注入** — 请求拦截器自动从 `getAccessToken` 获取 token 并注入请求头
- **主动刷新** — 返回 `AccessTokenDetail`（含 `expiresAt`）时，在 token 即将过期前异步触发刷新，不阻塞当前请求，默认提前 60s，可自定义 `refreshBufferMs`
- **被动刷新** — 收到 401 或业务响应命中时，自动刷新 token 并重放原请求
- **并发控制** — `TokenRefreshManager` 确保多个并发请求只触发一次刷新
- **业务错误归一化** — 统一处理业务失败响应，支持自定义判定和映射逻辑
- **向后兼容** — `getAccessToken` 可返回 `string` 或 `{ token, expiresAt, refreshBufferMs }`，旧用法不受影响

**其他变更：**

- 现有 API 模块（`account`、`auth`、`cat`、`group`、`permission`、`role`、`user`）迁移至 `new-http`
- 新增完整的单元测试和边界用例测试
- 新增 `http-demo.ts` 示例文件

#### 📝 补充信息 | Additional Information

**配置示例：**

```ts
const http = createHttpClient({
  axiosConfig: { baseURL: '/api' },
  getAccessToken: () => {
    const token = store.getState().jwtToken;
    if (!token?.accessToken) return null;
    return {
      token: token.accessToken,
      expiresAt: new Date(token.expiresAt),
      // refreshBufferMs: 60_000, // 可选，默认 1 分钟
    };
  },
  refreshAccessToken: () => refreshToken(),
  onAuthFailure: () => store.getState().logout(),
});
```

#### 🔗 关联 Issue | Related Issue

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time communication support (socket.io-client).

* **Chores**
  * Upgraded axios and added Vitest scripts (type-check, test, test:watch).
  * Introduced a new token-aware HTTP client with automatic token refresh and improved auth failure handling.
  * Migrated API callers to use the new HTTP client and adjusted TypeScript compiler options.

* **Documentation**
  * Added comprehensive README and a browser demo for the HTTP client.

* **Tests**
  * Added extensive tests and test utilities covering token refresh and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->