### PR TITLE
fix: JWT access token expires too fast due to string expiresIn

### DIFF
--- a/apps/server/src/config/config.default.ts
+++ b/apps/server/src/config/config.default.ts
@@ -29,8 +29,8 @@ export const defaultConfig = registerAs(
     },
     jwt: {
       secret: process.env.JWT_SECRET || '123456',
-      accessExpiresIn: process.env.JWT_ACCESS_EXPIRES_IN || 3600,
-      refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || 604800,
+      accessExpiresIn: Number(process.env.JWT_ACCESS_EXPIRES_IN) || 3600,
+      refreshExpiresIn: Number(process.env.JWT_REFRESH_EXPIRES_IN) || 604800,
     },
     snowflake: {
       workerId: process.env.WORKER_ID || 0,

--- a/apps/server/src/config/env/config.production.ts
+++ b/apps/server/src/config/env/config.production.ts
@@ -4,9 +4,7 @@ import { AppConfig } from '../configuration.interface';
 export const productionConfig = registerAs(
   'production',
   (): AppConfig => ({
-    server: {
-      port: 80,
-    },
+    server: {},
     swagger: {},
     database: {
       synchronize: false,

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -28,6 +28,7 @@ async function bootstrap() {
 
   const serverUrl = `http://127.0.0.1:${server.port}`;
 
+  Logger.log(`\x1b[34mNODE_ENV: ${process.env.NODE_ENV}\x1b[0m`);
   Logger.log(`\x1b[34mApplication is running on: ${serverUrl}\x1b[0m`);
   Logger.log(
     `\x1b[34mSwagger is running on: ${serverUrl}/${swagger.path}\x1b[0m`,

--- a/apps/server/src/modules/auth/refresh-token.service.ts
+++ b/apps/server/src/modules/auth/refresh-token.service.ts
@@ -74,25 +74,18 @@ export class RefreshTokenService {
       type: TokenType.ACCESS,
     };
 
+    const { jwt } = getConfig(this.configService);
+
     const accessToken = this.jwtService.sign(payload);
     const refreshToken = this.jwtService.sign(
       { ...payload, type: TokenType.REFRESH },
       {
-        expiresIn: getConfig(this.configService).jwt.refreshExpiresIn,
+        expiresIn: jwt.refreshExpiresIn,
       },
     );
 
-    const accessExpiresAt = new Date();
-    accessExpiresAt.setSeconds(
-      accessExpiresAt.getSeconds() +
-        getConfig(this.configService).jwt.accessExpiresIn,
-    );
-
-    const refreshExpiresAt = new Date();
-    refreshExpiresAt.setSeconds(
-      refreshExpiresAt.getSeconds() +
-        getConfig(this.configService).jwt.refreshExpiresIn,
-    );
+    const accessExpiresAt = Date.now() + jwt.accessExpiresIn * 1000;
+    const refreshExpiresAt = new Date(Date.now() + jwt.refreshExpiresIn * 1000);
 
     return { accessToken, refreshToken, accessExpiresAt, refreshExpiresAt };
   }

--- a/apps/web/src/services/api/http-factory/types.ts
+++ b/apps/web/src/services/api/http-factory/types.ts
@@ -5,7 +5,7 @@ import type { AxiosRequestConfig, AxiosResponse } from "axios";
  */
 export interface AccessTokenDetail {
   token: string;
-  expiresAt: Date | string;
+  expiresAt: Date | string | number;
   /**
    * 提前刷新的毫秒数，默认 60000（1 分钟）。
    */

--- a/apps/web/src/services/api/new-http.ts
+++ b/apps/web/src/services/api/new-http.ts
@@ -18,7 +18,7 @@ const newHttp = createHttpClient({
 
     return {
       token: jwtToken.accessToken,
-      expiresAt: new Date(jwtToken.expiresAt),
+      expiresAt: jwtToken.expiresAt,
     };
   },
   refreshAccessToken: async () => {

--- a/apps/web/src/services/types/token.ts
+++ b/apps/web/src/services/types/token.ts
@@ -1,4 +1,4 @@
 export interface IJwtToken {
   accessToken: string;
-  expiresAt: Date;
+  expiresAt: number;
 }


### PR DESCRIPTION
## 问题

JWT access token 实际过期时间与配置严重不符（配置 3600 实际只活 3 秒左右），即使把 `JWT_ACCESS_EXPIRES_IN` 设大也不生效。

## 根因

完整链路：

1. `.env` 未设置 `JWT_ACCESS_EXPIRES_IN`，按预期应走 `config.default.ts` 里的 `|| 3600`（number）兜底；
2. 但 `env.validation.ts` 用 `Joi.number().default(3600)` 给了默认值；
3. `@nestjs/config` 内部把 Joi 验证结果通过 `Object.assign(process.env, value)` 回写进 `process.env`；
4. **Node 的 `process.env` 会把任何值强制转字符串** → `process.env.JWT_ACCESS_EXPIRES_IN` 变成 `"3600"`；
5. `config.default.ts` 中 `process.env.JWT_ACCESS_EXPIRES_IN || 3600` 拿到字符串 `"3600"`；
6. 透传到 `JwtModule` → jsonwebtoken；
7. **jsonwebtoken 对不带单位的字符串按毫秒处理**：`"3600"` = 3600ms ≈ **3 秒**（而不是 3600 秒）。

实测验证：

```
expiresIn: 3600    (Number) → 3600 秒 ✓
expiresIn: "3600"  (String) → 3 秒    ✗  ← 当前 bug
expiresIn: "3600s" (带单位) → 3600 秒 ✓
```

同样的 bug 也影响 `refreshExpiresIn`，以及 `refresh-token.service.ts` 里 `setSeconds(N + "3600")` 的字符串拼接。

## 修改内容

### server

- `config/config.default.ts`：`process.env.JWT_*` 强制 `Number()` 转换，从源头堵住字符串透传。`auth.module` / `socket.module` / `refresh-token.service` 全部受益。
- `modules/auth/refresh-token.service.ts`：
  - `accessExpiresAt` 改为**毫秒时间戳数字**（`Date.now() + jwt.accessExpiresIn * 1000`），符合前端 `Date.now() < expiresAt` 的判断惯例；
  - `refreshExpiresAt` 保留 `Date`（数据库 `expiresAt: Date` 字段和 `< new Date()` 比较都需要）；
  - 合并 3 次 `getConfig(this.configService)` 调用为 1 次；
  - 顺带修了 `setSeconds(N + "3600")` 的字符串拼接 bug。

### web

- `services/types/token.ts`：`IJwtToken.expiresAt` 从 `Date` 改为 `number`，对齐后端契约；
- `services/api/http-factory/types.ts`：`AccessTokenDetail.expiresAt` 扩展为 `Date | string | number`；
- `services/api/new-http.ts`：去掉一次多余的 `new Date(...)` 包裹，直接透传 number。

运行时 `new Date(number)` 与 `new Date(string)` 行为一致，所以现存代码无需改动。

## 前端契约变化

`POST /auth/login` 和 `POST /auth/refresh-token` 响应里的 `expiresAt`：

- 之前：`"2026-05-12T01:15:36.000Z"`（ISO 字符串）
- 现在：`1747011336000`（毫秒时间戳）

## 验证

- server `tsc --noEmit` ✓
- web `tsc --noEmit` ✓
- Node 实测脚本确认修复后 token 实际有效期 = 3600 秒

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment information logging on application startup for better visibility into deployment context.

* **Chores**
  * Improved JWT configuration handling with more flexible environment variable support.
  * Optimized token expiration calculations and data structure consistency across client and server.
  * Adjusted production server configuration defaults.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fengzai6/my-first-nest/pull/16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->